### PR TITLE
Update Pectra/README.md: fix links to audit reports

### DIFF
--- a/Pectra/README.md
+++ b/Pectra/README.md
@@ -7,16 +7,16 @@ This repository contains the audit reports for the Pectra System Contracts, cove
 
 Each audit was performed sequentially in the order below and integrated fixes based on the previous reports, meaning that issues discovered by earlier auditors were typically resolved before the next audit commenced.
 
-1. **[Blackthorn Audit](Pectra/Blackthorn_Audit_2024_09_12_Final_Ethereum_Foundation_Blackthorn.pdf)**
+1. **[Blackthorn Audit](Blackthorn_Audit_2024_09_12_Final_Ethereum_Foundation_Blackthorn.pdf)**
 
 2. **Dedaub Audits**  
-   - [EIP2935](Pectra/Dedaub%20-%20EIP2935.pdf)  
-   - [EIP7002](Pectra/Dedaub%20-%20EIP7002.pdf)  
-   - [EIP7251](Pectra/Dedaub%20-%20EIP7251.pdf)  
+   - [EIP2935](Dedaub%20-%20EIP2935.pdf)
+   - [EIP7002](Dedaub%20-%20EIP7002.pdf)
+   - [EIP7251](Dedaub%20-%20EIP7251.pdf)
 
-3. **[PlainShift Audit](Pectra/Plainshift%20EF%20Pectra%20Audit.pdf)**
+3. **[PlainShift Audit](Plainshift%20EF%20Pectra%20Audit.pdf)**
 
-4. **[Sigma Prime Audit](Pectra/Sigma_Prime_Ethereum_Foundation_Pectra_System_Contracts_Bytecode.pdf)**
+4. **[Sigma Prime Audit](Sigma_Prime_Ethereum_Foundation_Pectra_System_Contracts_Bytecode.pdf)**
 
 ## Formal Verification
 


### PR DESCRIPTION
This fixes the links to the audit reports.